### PR TITLE
Add PR workflow build

### DIFF
--- a/.github/workflows/composite/bootstrap/action.yaml
+++ b/.github/workflows/composite/bootstrap/action.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: 'Setup build dependencies'
+description: 'Sets up the .NET dependencies of MSBuild, SDK, NuGet'
+inputs:
+  dotnet-version:
+    description: 'What .NET SDK version to use'
+    required: true
+    default: 6.0.x
+runs:
+  using: "composite"
+  steps:
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1.9.0
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.1
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1.0.5

--- a/.github/workflows/composite/vsixversion/action.yaml
+++ b/.github/workflows/composite/vsixversion/action.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: 'Increment VSIX Version'
+description: 'Increments the VSIX build version'
+inputs:
+  version-type:
+    description: 'Version type - build or revision'
+    required: true
+    default: 'build'
+  manifest-file:
+    description: 'Path to VSIX manifest'
+    requried: true
+  build-number:
+    description: 'Build number to use'
+    required: true
+    default: ${{ github.run_number }}
+outputs:
+  version-number:
+    description: 'The resulting version number'
+    value: ${{ steps.version_increment.outputs.version }}
+runs:
+  using: "composite"
+  steps:
+    - name: Increment VSIX version
+      id: version_increment
+      run: |
+        [xml]$vsixXml = Get-Content ${{ inputs.manifest-file }}
+
+        $ns = New-Object System.Xml.XmlNamespaceManager $vsixXml.NameTable
+        $ns.AddNamespace("ns", $vsixXml.DocumentElement.NamespaceURI) | Out-Null
+
+        $attrVersion = ""
+
+        if ($vsixXml.SelectSingleNode("//ns:Identity", $ns)){ # VS2012 format
+            $attrVersion = $vsixXml.SelectSingleNode("//ns:Identity", $ns).Attributes["Version"]
+        }
+        elseif ($vsixXml.SelectSingleNode("//ns:Version", $ns)){ # VS2010 format
+            $attrVersion = $vsixXml.SelectSingleNode("//ns:Version", $ns)
+        }
+
+        [Version]$version = $attrVersion.Value
+
+        if (!$attrVersion.Value){
+            $version = $attrVersion.InnerText
+        }
+
+        if (${{ inputs.version-type }} -eq "build"){
+            $version = New-Object Version ([int]$version.Major),([int]$version.Minor),${{ inputs.build-number }}
+        }
+        elseif (${{ inputs.version-type }} -eq "revision"){
+            $version = New-Object Version ([int]$version.Major),([int]$version.Minor),([System.Math]::Max([int]$version.Build, 0)),${{ inputs.build-number }}
+        }
+
+        $attrVersion.InnerText = $version
+
+        $vsixXml.Save($vsixManifest) | Out-Null
+
+        Write-Output "::set-output name=version::$version"

--- a/.github/workflows/composite/vsixversion/action.yaml
+++ b/.github/workflows/composite/vsixversion/action.yaml
@@ -53,6 +53,6 @@ runs:
 
         $attrVersion.InnerText = $version
 
-        $vsixXml.Save($vsixManifest) | Out-Null
+        $vsixXml.Save(${{ inputs.manifest-file }}) | Out-Null
 
         Write-Output "::set-output name=version::$version"

--- a/.github/workflows/composite/vsixversion/action.yaml
+++ b/.github/workflows/composite/vsixversion/action.yaml
@@ -13,6 +13,10 @@ inputs:
     description: 'Build number to use'
     required: true
     default: ${{ github.run_number }}
+  vsix-token-source-file:
+    description: 'Path to source.extension.vs'
+    required: false
+    default: ''
 outputs:
   version-number:
     description: 'The resulting version number'
@@ -56,3 +60,12 @@ runs:
         $vsixXml.Save("${{ inputs.manifest-file }}") | Out-Null
 
         Write-Output "::set-output name=version::$version"
+    - name: VSIX token replacement
+      if: inputs.vsix-token-source-file != '' && inputs.vsix-token-source-file != null
+      shell: pwsh
+      run: |
+        $filePath = "${{ inputs.vsix-token-source-file }}"
+        $replacement = 'Version = "${{ steps.vsix_version.outputs.version-number }}"'
+        $content = [string]::join([environment]::newline, (get-content $filePath))
+        $regex = New-Object System.Text.RegularExpressions.Regex 'Version = "([0-9\\.]+)"'
+        $regex.Replace($content, $replacement) | Out-File $FilePath

--- a/.github/workflows/composite/vsixversion/action.yaml
+++ b/.github/workflows/composite/vsixversion/action.yaml
@@ -53,6 +53,6 @@ runs:
 
         $attrVersion.InnerText = $version
 
-        $vsixXml.Save(${{ inputs.manifest-file }}) | Out-Null
+        $vsixXml.Save("${{ inputs.manifest-file }}") | Out-Null
 
         Write-Output "::set-output name=version::$version"

--- a/.github/workflows/composite/vsixversion/action.yaml
+++ b/.github/workflows/composite/vsixversion/action.yaml
@@ -22,6 +22,7 @@ runs:
   steps:
     - name: Increment VSIX version
       id: version_increment
+      shell: pwsh
       run: |
         [xml]$vsixXml = Get-Content ${{ inputs.manifest-file }}
 

--- a/.github/workflows/composite/vsixversion/action.yaml
+++ b/.github/workflows/composite/vsixversion/action.yaml
@@ -44,10 +44,10 @@ runs:
             $version = $attrVersion.InnerText
         }
 
-        if (${{ inputs.version-type }} -eq "build"){
+        if ("${{ inputs.version-type }}" -eq "build"){
             $version = New-Object Version ([int]$version.Major),([int]$version.Minor),${{ inputs.build-number }}
         }
-        elseif (${{ inputs.version-type }} -eq "revision"){
+        elseif ("${{ inputs.version-type }}" -eq "revision"){
             $version = New-Object Version ([int]$version.Major),([int]$version.Minor),([System.Math]::Max([int]$version.Build, 0)),${{ inputs.build-number }}
         }
 

--- a/.github/workflows/composite/vsixversion/action.yaml
+++ b/.github/workflows/composite/vsixversion/action.yaml
@@ -65,7 +65,7 @@ runs:
       shell: pwsh
       run: |
         $filePath = "${{ inputs.vsix-token-source-file }}"
-        $replacement = 'Version = "${{ steps.vsix_version.outputs.version-number }}"'
+        $replacement = 'Version = "${{ steps.version_increment.outputs.version }}"'
         $content = [string]::join([environment]::newline, (get-content $filePath))
         $regex = New-Object System.Text.RegularExpressions.Regex 'Version = "([0-9\\.]+)"'
         $regex.Replace($content, $replacement) | Out-File $FilePath

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup build dependencies
-      uses: ./.github/workflows/composite/bootstrap
+      uses: timheuer/bootstrap-dotnet@v1
 
     - name: Increment VSIX version
       id: vsix_version

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: "PR Build"
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.gitignore'
+      - '**/*.gitattributes'
+  workflow_dispatch:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.gitignore'
+      - '**/*.gitattributes'
+      
+jobs:
+  build:
+    name: Build 
+    runs-on: windows-2022
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_NOLOGO: true
+      DOTNET_GENERATE_ASPNET_CERTIFICATE: false
+      DOTNET_ADD_GLOBAL_TOOLS_TO_PATH: false
+      DOTNET_MULTILEVEL_LOOKUP: 0
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1.9
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Setup MSBuild
+      uses: actions/setup-msbuild@v1.1
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1.0.5
+
+      # TODO: Increment version and set in VSIX/nuspec/etc
+
+    - name: Restore
+      run: nuget restore -Verbosity quiet
+
+    - name: Build
+      run: msbuild src\RestClientVS\RestClientVS.csproj /p:Configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:m /p:OutDir=../../built
+
+    - name: Test
+      run: dotnet test test/RestClientTest/RestClientTest.csproj
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: RestClientVS.vsix
+        path: built

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -58,4 +58,4 @@ jobs:
       uses: actions/upload-artifact@v1.0.0
       with:
         name: RestClientVS.vsix
-        path: built
+        path: built/*.vsix

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -28,7 +28,6 @@ jobs:
       DOTNET_GENERATE_ASPNET_CERTIFICATE: false
       DOTNET_ADD_GLOBAL_TOOLS_TO_PATH: false
       DOTNET_MULTILEVEL_LOOKUP: 0
-      VSIX_VERSION: 1.0.${{ github.run_number }}
       
     steps:
     - uses: actions/checkout@v2
@@ -36,10 +35,16 @@ jobs:
     - name: Setup build dependencies
       uses: ./.github/workflows/composite/bootstrap
 
+    - name: Increment VSIX version
+      id: vsix_version
+      uses: ./.github/workflows/composite/vsixversion
+      with:
+        manifest-file: src\RestClientVS\source.extension.vsixmanifest
+
     - name: Set version for Visual Studio Extension
       uses: cezarypiatek/VsixVersionAction@1.0
       with:
-        version: ${{ env.VSIX_VERSION }}
+        version: ${{ steps.vsix_version.outputs.version-number }}
         vsix-manifest-file: src\RestClientVS\source.extension.vsixmanifest
 
     - name: VSIX token replacement

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -51,7 +51,7 @@ jobs:
       shell: pwsh
       run: |
         $filePath = "src\RestClientVS\source.extension.cs"
-        $replacement = 'Version = "${{ env.VSIX_VERSION }}"'
+        $replacement = 'Version = "${{ steps.vsix_version.outputs.version-number }}"'
         $content = [string]::join([environment]::newline, (get-content $filePath))
         $regex = New-Object System.Text.RegularExpressions.Regex 'Version = "([0-9\\.]+)"'
         $regex.Replace($content, $replacement) | Out-File $FilePath

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup build dependencies
-      uses: timheuer/bootstrap-dotnet@v1
+      uses: ./.github/workflows/composite/bootstrap
 
     - name: Increment VSIX version
       id: vsix_version

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -28,7 +28,8 @@ jobs:
       DOTNET_GENERATE_ASPNET_CERTIFICATE: false
       DOTNET_ADD_GLOBAL_TOOLS_TO_PATH: false
       DOTNET_MULTILEVEL_LOOKUP: 0
-
+      VSIX_VERSION: 1.0.${{ github.run_number }}
+      
     steps:
     - uses: actions/checkout@v2
       
@@ -46,8 +47,17 @@ jobs:
     - name: Set version for Visual Studio Extension
       uses: cezarypiatek/VsixVersionAction@1.0
       with:
-        version: 1.0.${{ github.run_number }}
+        version: ${{ env.VSIX_VERSION }}
         vsix-manifest-file: src\RestClientVS\source.extension.vsixmanifest
+
+    - name: VSIX token replacement
+      shell: pwsh
+      run: |
+        $filePath = "src\RestClientVS\source.extension.cs"
+        $replacement = 'Version = "${{ env.VSIX_VERSION }}"'
+        $content = [string]::join([environment]::newline, (get-content $filePath))
+        $regex = New-Object System.Text.RegularExpressions.Regex 'Version = "([0-9\\.]+)"'
+        $regex.Replace($content, $replacement) | Out-File $FilePath
 
     - name: Restore
       run: nuget restore -Verbosity quiet

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -40,15 +40,7 @@ jobs:
       uses: ./.github/workflows/composite/vsixversion
       with:
         manifest-file: src\RestClientVS\source.extension.vsixmanifest
-
-    - name: VSIX token replacement
-      shell: pwsh
-      run: |
-        $filePath = "src\RestClientVS\source.extension.cs"
-        $replacement = 'Version = "${{ steps.vsix_version.outputs.version-number }}"'
-        $content = [string]::join([environment]::newline, (get-content $filePath))
-        $regex = New-Object System.Text.RegularExpressions.Regex 'Version = "([0-9\\.]+)"'
-        $regex.Replace($content, $replacement) | Out-File $FilePath
+        vsix-token-source-file: src\RestClientVS\source.extension.cs
 
     - name: Restore
       run: nuget restore -Verbosity quiet

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -32,17 +32,9 @@ jobs:
       
     steps:
     - uses: actions/checkout@v2
-      
-    - name: Setup dotnet
-      uses: actions/setup-dotnet@v1.9.0
-      with:
-        dotnet-version: 6.0.x
 
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.1
-
-    - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.5
+    - name: Setup build dependencies
+      uses: ./.github/workflows/composite/bootstrap
 
     - name: Set version for Visual Studio Extension
       uses: cezarypiatek/VsixVersionAction@1.0

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -43,8 +43,11 @@ jobs:
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
 
-      # TODO: Increment version and set in VSIX/nuspec/etc
-      # github.run_number
+    - name: Set version for Visual Studio Extension
+      uses: cezarypiatek/VsixVersionAction@1.0
+      with:
+        version: 1.0.${{ github.run_number }}
+        vsix-manifest-file: src\RestClientVS\source.extension.vsixmanifest
 
     - name: Restore
       run: nuget restore -Verbosity quiet

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -41,12 +41,6 @@ jobs:
       with:
         manifest-file: src\RestClientVS\source.extension.vsixmanifest
 
-    - name: Set version for Visual Studio Extension
-      uses: cezarypiatek/VsixVersionAction@1.0
-      with:
-        version: ${{ steps.vsix_version.outputs.version-number }}
-        vsix-manifest-file: src\RestClientVS\source.extension.vsixmanifest
-
     - name: VSIX token replacement
       shell: pwsh
       run: |

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -33,12 +33,12 @@ jobs:
     - uses: actions/checkout@v2
       
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v1.9
+      uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: 6.0.x
 
     - name: Setup MSBuild
-      uses: actions/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -32,8 +32,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup build dependencies
-      uses: ./.github/workflows/composite/bootstrap
+    - name: Setup .NET build dependencies
+      uses: timheuer/bootstrap-dotnet@v1
 
     - name: Increment VSIX version
       id: vsix_version

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -44,6 +44,7 @@ jobs:
       uses: NuGet/setup-nuget@v1.0.5
 
       # TODO: Increment version and set in VSIX/nuspec/etc
+      # github.run_number
 
     - name: Restore
       run: nuget restore -Verbosity quiet
@@ -55,7 +56,7 @@ jobs:
       run: dotnet test test/RestClientTest/RestClientTest.csproj
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v2
       with:
         name: RestClientVS.vsix
-        path: built/*.vsix
+        path: built/**/*.vsix

--- a/RestClientVS.sln
+++ b/RestClientVS.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{99EE9F4E-D9B
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{88B160D5-D161-408D-9CDB-D77AF3F3B14E}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\composite\bootstrap\action.yaml = .github\workflows\composite\bootstrap\action.yaml
 		appveyor.yml = appveyor.yml
 		.github\workflows\pr_build.yaml = .github\workflows\pr_build.yaml
 		README.md = README.md

--- a/RestClientVS.sln
+++ b/RestClientVS.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{99EE9F4E-D9B
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{88B160D5-D161-408D-9CDB-D77AF3F3B14E}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\composite\vsixversion\action.yaml = .github\workflows\composite\vsixversion\action.yaml
 		.github\workflows\composite\bootstrap\action.yaml = .github\workflows\composite\bootstrap\action.yaml
 		appveyor.yml = appveyor.yml
 		.github\workflows\pr_build.yaml = .github\workflows\pr_build.yaml

--- a/RestClientVS.sln
+++ b/RestClientVS.sln
@@ -16,6 +16,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{88B160D5-D161-408D-9CDB-D77AF3F3B14E}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
+		.github\workflows\pr_build.yaml = .github\workflows\pr_build.yaml
 		README.md = README.md
 	EndProjectSection
 EndProject


### PR DESCRIPTION
This adds a GitHub Actions workflow for pull requests only as a start (so no publish to VSIX gallery).  Emulates current workflow and steps used by the VSIX powershell scripts but only uses one snippet of that and now embedded in the workflow (probably a generic pattern replace action that could even be replaced with but the pwsh script does the job and is fast)