### PR TITLE
Fix link to the original vscode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ or get the [CI build](https://www.vsixgallery.com/extension/RestClientVS.a7b4a36
 
 -----------------------------------
 
-REST Client allows you to send HTTP request and view the response in Visual Studio directly. Based on the popular VS Code extension [Rest Client][vsixgallery] by [Huachao Mao](https://github.com/Huachao)
+REST Client allows you to send HTTP request and view the response in Visual Studio directly. Based on the popular VS Code extension [Rest Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) by [Huachao Mao](https://github.com/Huachao)
 
 ![Screenshot](art/screenshot.png)
 


### PR DESCRIPTION
I suppose you want that link to go to the vscode extension and not point back to this one?