### PR TITLE
Add basic formatting for JSON and XML results

### DIFF
--- a/src/RestClientVS/Margin/ResponseControl.xaml.cs
+++ b/src/RestClientVS/Margin/ResponseControl.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows.Controls;
+﻿using System.Text;
+using System.Windows.Controls;
+using System.Xml.Linq;
+using Newtonsoft.Json.Linq;
 using RestClient.Client;
 
 namespace RestClientVS.Margin
@@ -14,7 +17,43 @@ namespace RestClientVS.Margin
         {
             if (result.Response != null)
             {
-                Control.Text = await result.Response.ToRawStringAsync();
+                var text = new StringBuilder();
+                switch (result.Response.Content.Headers.ContentType.MediaType)
+                {
+                    case "application/json":
+                        var jsonString = await result.Response.Content.ReadAsStringAsync();
+                        text.AppendLine(result.Response.Headers.ToString());
+                        try
+                        {
+                            var jsonObject = JObject.Parse(jsonString);
+                            text.AppendLine(jsonObject.ToString());
+                        }
+                        catch (Exception ex)
+                        {
+                            text.AppendFormat("** {0} : Error parsing JSON ( {1} ), raw content follows. **\r\r", nameof(RestClientVS), ex.GetBaseException().Message);
+                            text.AppendLine(jsonString);
+                        }
+                        Control.Text = text.ToString();
+                        break;
+                    case "application/xml":
+                        var xmlString = await result.Response.Content.ReadAsStringAsync();
+                        text.AppendLine(result.Response.Headers.ToString());
+                        try
+                        {
+                            var xmlElement = XElement.Parse(xmlString);
+                            text.AppendLine(xmlElement.ToString());
+                        }
+                        catch (Exception ex)
+                        {
+                            text.AppendFormat("** {0} : Error parsing XML ( {1} ), raw content follows. **\r\r", nameof(RestClientVS), ex.GetBaseException().Message);
+                            text.AppendLine(xmlString);
+                        }
+                        Control.Text = text.ToString();
+                        break;
+                    default:
+                        Control.Text = await result.Response.ToRawStringAsync();
+                        break;
+                }
             }
             else
             {

--- a/src/RestClientVS/Margin/ResponseControl.xaml.cs
+++ b/src/RestClientVS/Margin/ResponseControl.xaml.cs
@@ -18,42 +18,42 @@ namespace RestClientVS.Margin
             if (result.Response != null)
             {
                 var text = new StringBuilder();
-                switch (result.Response.Content.Headers.ContentType.MediaType)
+                var mediaType = result.Response.Content.Headers.ContentType.MediaType;
+                if (mediaType.IndexOf("json", StringComparison.OrdinalIgnoreCase) > -1)
                 {
-                    case "application/json":
-                        var jsonString = await result.Response.Content.ReadAsStringAsync();
-                        text.AppendLine(result.Response.Headers.ToString());
-                        try
-                        {
-                            var jsonObject = JObject.Parse(jsonString);
-                            text.AppendLine(jsonObject.ToString());
-                        }
-                        catch (Exception ex)
-                        {
-                            text.AppendFormat("** {0} : Error parsing JSON ( {1} ), raw content follows. **\r\r", nameof(RestClientVS), ex.GetBaseException().Message);
-                            text.AppendLine(jsonString);
-                        }
-                        Control.Text = text.ToString();
-                        break;
-                    case "application/xml":
-                        var xmlString = await result.Response.Content.ReadAsStringAsync();
-                        text.AppendLine(result.Response.Headers.ToString());
-                        try
-                        {
-                            var xmlElement = XElement.Parse(xmlString);
-                            text.AppendLine(xmlElement.ToString());
-                        }
-                        catch (Exception ex)
-                        {
-                            text.AppendFormat("** {0} : Error parsing XML ( {1} ), raw content follows. **\r\r", nameof(RestClientVS), ex.GetBaseException().Message);
-                            text.AppendLine(xmlString);
-                        }
-                        Control.Text = text.ToString();
-                        break;
-                    default:
-                        Control.Text = await result.Response.ToRawStringAsync();
-                        break;
+                    var jsonString = await result.Response.Content.ReadAsStringAsync();
+                    text.AppendLine(result.Response.Headers.ToString());
+                    try
+                    {
+                        var jsonObject = JObject.Parse(jsonString);
+                        text.AppendLine(jsonObject.ToString());
+                    }
+                    catch (Exception ex)
+                    {
+                        text.AppendFormat("** {0} : Error parsing JSON ( {1} ), raw content follows. **\r\r", nameof(RestClientVS), ex.GetBaseException().Message);
+                        text.AppendLine(jsonString);
+                    }
+                    Control.Text = text.ToString();
+                    return;
                 }
+                if (mediaType.IndexOf("xml", StringComparison.OrdinalIgnoreCase) > -1)
+                {
+                    var xmlString = await result.Response.Content.ReadAsStringAsync();
+                    text.AppendLine(result.Response.Headers.ToString());
+                    try
+                    {
+                        var xmlElement = XElement.Parse(xmlString);
+                        text.AppendLine(xmlElement.ToString());
+                    }
+                    catch (Exception ex)
+                    {
+                        text.AppendFormat("** {0} : Error parsing XML ( {1} ), raw content follows. **\r\r", nameof(RestClientVS), ex.GetBaseException().Message);
+                        text.AppendLine(xmlString);
+                    }
+                    Control.Text = text.ToString();
+                    return;
+                }
+                Control.Text = await result.Response.ToRawStringAsync();
             }
             else
             {

--- a/src/RestClientVS/RestClientVS.csproj
+++ b/src/RestClientVS/RestClientVS.csproj
@@ -108,6 +108,7 @@
     <Reference Include="System.Design" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This partially addresses #10 - basic formatting

I would welcome a review as I have kept it simple (maybe too simple?) and only look for two `MediaType`s.


