### PR TITLE
Enable Focusable on the ResponseControl Textbox

### DIFF
--- a/src/RestClientVS/Margin/ResponseControl.xaml
+++ b/src/RestClientVS/Margin/ResponseControl.xaml
@@ -17,7 +17,7 @@
                  Padding="10"
                  BorderThickness="0"
                  IsReadOnly="True"
-								 Focusable="True"
+                 Focusable="True"
                  FontFamily="Cascadia Mono"/>
     </Grid>
 </UserControl>

--- a/src/RestClientVS/Margin/ResponseControl.xaml
+++ b/src/RestClientVS/Margin/ResponseControl.xaml
@@ -17,6 +17,7 @@
                  Padding="10"
                  BorderThickness="0"
                  IsReadOnly="True"
+								 Focusable="True"
                  FontFamily="Cascadia Mono"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Enable Focusable on the ResponseControl Textbox - to allow keyboard commands like Select All and Copy to work.

This fixes #18 