### PR TITLE
Allow unconventional headers

### DIFF
--- a/src/RestClient/Client/RequestSender.cs
+++ b/src/RestClient/Client/RequestSender.cs
@@ -91,7 +91,7 @@ namespace RestClient.Client
                     }
                     else
                     {
-                        message.Headers.Add(name, value);
+                        message.Headers.TryAddWithoutValidation(name, value);
                     }
                 }
             }


### PR DESCRIPTION
such as "Authorization: {some really lo……ng token with no scheme}"

Rationale: I needed it for a 3rd party API that requires this format, but `Headers.Add()` was throwing an `InvalidFormatException`.

As this is a tool for testing APIs, and the error thrown by this is swallowed - so the user has no idea the header was not added, it makes more sense to allow the header to be added regardless of validation.