### PR TITLE
Fixes https://github.com/madskristensen/RestClientVS/issues/31

### DIFF
--- a/src/RestClient/Parser/DocumentParser.cs
+++ b/src/RestClient/Parser/DocumentParser.cs
@@ -260,7 +260,7 @@ namespace RestClient
                         }
 
                         var prevEmptyLine = item.Previous?.Type == ItemType.Body && string.IsNullOrWhiteSpace(item.Previous.Text) ? item.Previous.Text : "";
-                        currentRequest.Body += prevEmptyLine + item.Text;
+                        currentRequest.Body += prevEmptyLine + item.TextExcludingLineBreaks;
                         currentRequest?.Children?.Add(item);
                     }
                     else if (item?.Type == ItemType.Comment)


### PR DESCRIPTION
This fixes https://github.com/madskristensen/RestClientVS/issues/31 by excluding line break characters in the request body when urlencoded.

This allows the following types of requests to succeed:

POST https://myserver/mypath/myoperation HTTP/1.1
content-type: application/x-www-form-urlencoded

f=json
&inputLocations=123,45;123,46