### PR TITLE
Handle content-type header when charset or other additional values present

### DIFF
--- a/src/RestClient/Client/RequestSender.cs
+++ b/src/RestClient/Client/RequestSender.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace RestClient.Client
 {
-    public class RequestSender
+    public static class RequestSender
     {
 
 
@@ -76,7 +76,7 @@ namespace RestClient.Client
             message.Content = new StringContent(request.ExpandBodyVariables());
         }
 
-        private static void AddHeaders(Request request, HttpRequestMessage message)
+        public static void AddHeaders(Request request, HttpRequestMessage message)
         {
             if (request.Headers != null)
             {
@@ -87,12 +87,13 @@ namespace RestClient.Client
 
                     if (name!.Equals("content-type", StringComparison.OrdinalIgnoreCase) && request.Body != null)
                     {
-                        message.Content = new StringContent(request.ExpandBodyVariables(), System.Text.Encoding.UTF8, value);
+                        // Remove name-value pairs that can follow the MIME type
+                        string mimeType = value!.Split(';')[0];
+
+                        message.Content = new StringContent(request.ExpandBodyVariables(), System.Text.Encoding.UTF8, mimeType);
                     }
-                    else
-                    {
-                        message.Headers.TryAddWithoutValidation(name, value);
-                    }
+
+                    message.Headers.TryAddWithoutValidation(name, value);
                 }
             }
 

--- a/src/RestClient/Client/RequestSender.cs
+++ b/src/RestClient/Client/RequestSender.cs
@@ -88,7 +88,7 @@ namespace RestClient.Client
                     if (name!.Equals("content-type", StringComparison.OrdinalIgnoreCase) && request.Body != null)
                     {
                         // Remove name-value pairs that can follow the MIME type
-                        string mimeType = value!.Split(';')[0];
+                        string mimeType = value!.GetFirstToken();
 
                         message.Content = new StringContent(request.ExpandBodyVariables(), System.Text.Encoding.UTF8, mimeType);
                     }

--- a/src/RestClient/Parser/DocumentParser.cs
+++ b/src/RestClient/Parser/DocumentParser.cs
@@ -264,7 +264,7 @@ namespace RestClient
                         }
 
                         var prevEmptyLine = item.Previous?.Type == ItemType.Body && string.IsNullOrWhiteSpace(item.Previous.Text) ? item.Previous.Text : "";
-                        string content = isWwwForm ? item.TextExcludingLineBreaks: item.Text;
+                        string content = isWwwForm ? item.TextExcludingLineBreaks : item.Text;
                         currentRequest.Body += prevEmptyLine + content;
                         currentRequest?.Children?.Add(item);
                     }

--- a/src/RestClient/Parser/StringExtensions.cs
+++ b/src/RestClient/Parser/StringExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace RestClient
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Performs culture-invariant, case insensitive comparison to see if a string
+        /// is a match for the supplied token string. The test string is trimmed of
+        /// spaces first.
+        /// </summary>
+        public static bool IsTokenMatch(this string input, string token) =>
+            string.Compare(input.Trim(), token, StringComparison.InvariantCultureIgnoreCase) == 0;
+
+        /// <summary>
+        /// Returns the first token from a list of tokens with the specified separator.
+        /// This is used mainly to fetch the MIME type from content-type headers.
+        /// </summary>
+        public static string GetFirstToken(this string input, char separator = ';') =>
+            input.Split(separator)[0];
+    }
+}

--- a/test/RestClientTest/HttpTest.cs
+++ b/test/RestClientTest/HttpTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using RestClient;
 using RestClient.Client;
@@ -23,6 +24,39 @@ namespace RestClientTest
 
             Assert.NotNull(client.Response);
             Assert.True(raw.Length > 50);
+        }
+
+        [Theory]
+        [InlineData("application/json")]
+        [InlineData("application/json; charset=utf-8")]
+        public void AddHeadersParseContentTypeTest(string contentType)
+        {
+            var lines = new[]
+            {
+                "POST https://test.fake/api/users/add HTTP/1.1",
+                "Content-type: " + contentType,
+                "Accept: application/json",
+                "",
+                "{",
+                "}"
+            };
+
+            var doc = Document.FromLines(lines);
+
+            Request request = doc.Requests?.FirstOrDefault();
+
+            //var nullParseItem = new ParseItem(0, string.Empty, doc, ItemType.EmptyLine);
+
+            //var request = new Request(doc, nullParseItem, nullParseItem, null);
+
+            HttpRequestMessage message = new();
+
+            RequestSender.AddHeaders(request, message);
+
+            Assert.Equal(contentType,
+                request.Headers.Where(
+                h => string.Compare(h.Name.Text, "content-type", StringComparison.InvariantCultureIgnoreCase) == 0)
+                .First().Value.Text.Trim());
         }
     }
 }

--- a/test/RestClientTest/HttpTest.cs
+++ b/test/RestClientTest/HttpTest.cs
@@ -45,10 +45,6 @@ namespace RestClientTest
 
             Request request = doc.Requests?.FirstOrDefault();
 
-            //var nullParseItem = new ParseItem(0, string.Empty, doc, ItemType.EmptyLine);
-
-            //var request = new Request(doc, nullParseItem, nullParseItem, null);
-
             HttpRequestMessage message = new ();
 
             RequestSender.AddHeaders(request, message);

--- a/test/RestClientTest/HttpTest.cs
+++ b/test/RestClientTest/HttpTest.cs
@@ -31,7 +31,7 @@ namespace RestClientTest
         [InlineData("application/json; charset=utf-8")]
         public void AddHeadersParseContentTypeTest(string contentType)
         {
-            var lines = new[]
+            var lines = new[] 
             {
                 "POST https://test.fake/api/users/add HTTP/1.1",
                 "Content-type: " + contentType,
@@ -49,13 +49,13 @@ namespace RestClientTest
 
             //var request = new Request(doc, nullParseItem, nullParseItem, null);
 
-            HttpRequestMessage message = new();
+            HttpRequestMessage message = new ();
 
             RequestSender.AddHeaders(request, message);
 
-            Assert.Equal(contentType,
+            Assert.Equal(contentType, 
                 request.Headers.Where(
-                h => string.Compare(h.Name.Text, "content-type", StringComparison.InvariantCultureIgnoreCase) == 0)
+                h => h.Name.Text.IsTokenMatch("content-type"))
                 .First().Value.Text.Trim());
         }
     }

--- a/test/RestClientTest/TokenTest.cs
+++ b/test/RestClientTest/TokenTest.cs
@@ -105,6 +105,25 @@ namespace RestClientTest
         }
 
         [Fact]
+        public void RequestWithHeaderAndMultilineWwwFormBody()
+        {
+            var lines = new[]
+            {
+                "POST https://myserver/mypath/myoperation HTTP/1.1",
+                "content-type: application/x-www-form-urlencoded; charset=utf-8",
+                "\r\n",
+                "f=json\r\n",
+                "&inputLocations=123,45;123,46\r\n"
+            };
+
+            var doc = Document.FromLines(lines);
+            Request request = doc.Requests.First();
+
+            Assert.NotNull(request.Body);
+            Assert.Equal("f=json&inputLocations=123,45;123,46", request.Body);
+        }
+
+        [Fact]
         public void RequestWithHeaderAndBodyAndComment()
         {
             var lines = new[]


### PR DESCRIPTION
Fix for content-type headers which include content beyond just the MIME type (application/json; charset=utf-8). The VS Code version of the extension was able to handle that, so it seemed reasonable that this should - it also possibly coincides with [https://github.com/madskristensen/RestClientVS/issues/30](https://github.com/madskristensen/RestClientVS/issues/30) (Also content-type header was stripped from output request, now it is passed through).

Correction for [https://github.com/madskristensen/RestClientVS/issues/31](https://github.com/madskristensen/RestClientVS/issues/31) which removed LF/CR uncritically, when it should only have done so for **application/x-www-form-urlencoded**. This had caused a unit test failure, which now passes as a result of this correction.